### PR TITLE
حل مشکل چند عدد در متن

### DIFF
--- a/IranSystemConvertor/ConvertTo.cs
+++ b/IranSystemConvertor/ConvertTo.cs
@@ -294,7 +294,7 @@ namespace IranSystemConvertor
                 string number = Reverse(NumbersInTheString.Pop());
                 if(!string.IsNullOrWhiteSpace(number))
                 {
-                    int index = convertedString.IndexOf("#");
+                    int index = convertedString.LastIndexOf("#");
 
                     convertedString = convertedString.Remove(index, 1);
                     convertedString = convertedString.Insert(index, number);


### PR DESCRIPTION
اعداد داخل یک استک پوش میشوند ، برای حل مشکل اعداد آخرین کاراکتر # در رشته با بالاترین آیتم استک replace شود. 
با تغییر خط :
int index = convertedString.IndexOf("#");
به
int index = convertedString.LastIndexOf("#");
ایشوهای #8  و #4  برطرف خواهند شد